### PR TITLE
fix(decryptor): accept Uint8Array/other buffers in decryptValue

### DIFF
--- a/src/decryptor.ts
+++ b/src/decryptor.ts
@@ -10,9 +10,14 @@ export class CookieDecryptor {
     'Edge Safe Storage'
   ];
 
-  static decryptValue(encryptedValue: Buffer | Uint8Array | any): string {
+  /**
+   * Decrypt a cookie value that may be a Buffer, Uint8Array, or ArrayBuffer.
+   */
+  static decryptValue(encryptedValue: Buffer | Uint8Array | ArrayBuffer): string {
     // Ensure we have a Buffer to work with
-    const buffer = Buffer.isBuffer(encryptedValue) ? encryptedValue : Buffer.from(encryptedValue);
+    const buffer = Buffer.isBuffer(encryptedValue)
+      ? encryptedValue
+      : Buffer.from(encryptedValue as Uint8Array | ArrayBuffer);
     if (os.platform() !== 'darwin') {
       // Non-macOS platforms - return as is (might not be encrypted)
       return buffer.toString('utf8');

--- a/src/decryptor.ts
+++ b/src/decryptor.ts
@@ -10,16 +10,18 @@ export class CookieDecryptor {
     'Edge Safe Storage'
   ];
 
-  static decryptValue(encryptedValue: Buffer): string {
+  static decryptValue(encryptedValue: Buffer | Uint8Array | any): string {
+    // Ensure we have a Buffer to work with
+    const buffer = Buffer.isBuffer(encryptedValue) ? encryptedValue : Buffer.from(encryptedValue);
     if (os.platform() !== 'darwin') {
       // Non-macOS platforms - return as is (might not be encrypted)
-      return encryptedValue.toString('utf8');
+      return buffer.toString('utf8');
     }
 
     try {
       // Check for Chrome v80+ encryption prefix
-      if (encryptedValue.subarray(0, 3).toString() === 'v10' || 
-          encryptedValue.subarray(0, 3).toString() === 'v11') {
+      if (buffer.subarray(0, 3).toString() === 'v10' || 
+          buffer.subarray(0, 3).toString() === 'v11') {
         
         // Get Chrome Safe Storage password from Keychain
         const password = this.getChromeSafeStoragePassword();
@@ -35,7 +37,7 @@ export class CookieDecryptor {
         const key = crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha1');
 
         // Extract the encrypted data after removing v10/v11 prefix
-        const encryptedData = encryptedValue.subarray(3); // Remove v10/v11 prefix
+        const encryptedData = buffer.subarray(3); // Remove v10/v11 prefix
         
         // Use AES-CBC decryption based on pycookiecheat implementation
         try {
@@ -68,7 +70,7 @@ export class CookieDecryptor {
         return '[ENCRYPTED]';
       } else {
         // Older encryption format or unencrypted
-        const result = encryptedValue.toString('utf8');
+        const result = buffer.toString('utf8');
         // Check if it looks like valid cookie data (no null bytes)
         if (result && result.length > 0 && !result.includes('\0')) {
           return result;

--- a/tests/extractor-db.test.ts
+++ b/tests/extractor-db.test.ts
@@ -1,0 +1,165 @@
+const mockDb = {
+  close: jest.fn(),
+  all: jest.fn(),
+  run: jest.fn()
+};
+
+jest.mock('sqlite3', () => ({
+  Database: jest.fn((path: string, mode: any, cb: any) => {
+    const db = mockDb;
+    if (cb) {
+      setImmediate(() => cb(null));
+    }
+    return db;
+  }),
+  OPEN_READONLY: 0
+}));
+
+import { ChromeCookieExtractor } from '../src/extractor';
+import { CookieDecryptor } from '../src/decryptor';
+import { ProfileDetector } from '../src/profile-detector';
+import * as sqlite3 from 'sqlite3';
+const fsMock = require('fs');
+
+jest.mock('../src/profile-detector', () => ({
+  ProfileDetector: { detectAllProfiles: jest.fn(() => [{ name: 'Default', path: '/p', cookiesPath: '/p/Cookies' }]) }
+}));
+
+describe('ChromeCookieExtractor database operations', () => {
+  const tableInfoRows = [
+    { name: 'name' },
+    { name: 'value' },
+    { name: 'encrypted_value' },
+    { name: 'host_key' },
+    { name: 'path' },
+    { name: 'expires_utc' },
+    { name: 'is_secure' },
+    { name: 'is_httponly' },
+    { name: 'creation_utc' }
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.all.mockReset();
+    mockDb.run.mockReset();
+    mockDb.close.mockReset();
+  });
+
+  it('extractFromDatabase returns decrypted cookies', async () => {
+    const encryptedBuffer = Buffer.from('encrypted');
+    mockDb.run.mockImplementation((q, cb) => cb(null));
+    mockDb.all.mockImplementationOnce((q, cb) => cb(null, tableInfoRows));
+    mockDb.all.mockImplementationOnce((q, params, cb) => cb(null, [{
+      name: 'sid',
+      value: '',
+      encrypted_value: encryptedBuffer,
+      host_key: 'example.com',
+      path: '/',
+      expires_utc: 0,
+      is_secure: 0,
+      is_httponly: 1,
+      creation_utc: 0
+    }]));
+    jest.spyOn(CookieDecryptor, 'decryptValue').mockReturnValue('decrypted');
+    const ex = new ChromeCookieExtractor();
+    const res = await (ex as any).extractFromDatabase('/p/Cookies', 'example');
+    expect(res[0].value).toBe('decrypted');
+  });
+
+  it('extractFromDatabase handles plain values', async () => {
+    mockDb.run.mockImplementation((q, cb) => cb(null));
+    mockDb.all.mockImplementationOnce((q, cb) => cb(null, tableInfoRows.filter(r => r.name !== 'encrypted_value')));
+    mockDb.all.mockImplementationOnce((q, params, cb) => cb(null, [{
+      name: 'sid',
+      value: 'plain',
+      host_key: 'example.com',
+      path: '/',
+      expires_utc: 0,
+      is_secure: 0,
+      is_httponly: 1,
+      creation_utc: 0
+    }]));
+    const ex = new ChromeCookieExtractor();
+    const res = await (ex as any).extractFromDatabase('/p/Cookies');
+    expect(res[0].value).toBe('plain');
+  });
+
+  it('uses fallback value when decryption fails', async () => {
+    const encryptedBuffer = Buffer.from('enc');
+    mockDb.run.mockImplementation((q, cb) => cb(null));
+    mockDb.all.mockImplementationOnce((q, cb) => cb(null, tableInfoRows));
+    mockDb.all.mockImplementationOnce((q, params, cb) => cb(null, [{
+      name: 'sid',
+      value: 'abc',
+      encrypted_value: encryptedBuffer,
+      host_key: 'example.com',
+      path: '/',
+      expires_utc: 0,
+      is_secure: 0,
+      is_httponly: 0,
+      creation_utc: 0
+    }]));
+    jest.spyOn(CookieDecryptor, 'decryptValue').mockReturnValue('[ENCRYPTED]');
+    const ex = new ChromeCookieExtractor();
+    const res = await (ex as any).extractFromDatabase('/p/Cookies');
+    expect(res[0].value).toBe('abc');
+  });
+
+  it('falls back to copy when open fails', async () => {
+    (sqlite3 as any).Database.mockImplementationOnce((p: string, m: any, cb: any) => { setImmediate(() => cb(new Error('fail'))); return mockDb; });
+    const ex = new ChromeCookieExtractor();
+    const spy = jest.spyOn(ex as any, 'extractFromDatabaseWithCopy').mockResolvedValue([]);
+    await (ex as any).extractFromDatabase('/p/Cookies');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('extractFromDatabase rejects on schema error', async () => {
+    mockDb.run.mockImplementation((q, cb) => cb(null));
+    mockDb.all.mockImplementationOnce((q, cb) => cb(new Error('fail')));
+    const ex = new ChromeCookieExtractor();
+    await expect((ex as any).extractFromDatabase('/p/Cookies')).rejects.toBeTruthy();
+  });
+
+  it('extractFromDatabaseWithCopy uses temp copy', async () => {
+    (fsMock as any).copyFileSync = jest.fn();
+    (fsMock as any).unlinkSync = jest.fn();
+    (fsMock as any).existsSync = jest.fn(() => true);
+
+    mockDb.run.mockImplementation((q, cb) => cb(null));
+    mockDb.all.mockImplementationOnce((q, cb) => cb(null, tableInfoRows));
+    mockDb.all.mockImplementationOnce((q, params, cb) => cb(null, []));
+    (sqlite3 as any).Database.mockImplementationOnce((p: string, m: any, cb: any) => { setImmediate(() => cb(null)); return mockDb; });
+
+    const ex = new ChromeCookieExtractor();
+    await (ex as any).extractFromDatabaseWithCopy('/p/Cookies');
+    expect((fsMock as any).copyFileSync).toHaveBeenCalled();
+    expect((fsMock as any).unlinkSync).toHaveBeenCalled();
+  });
+
+  it('extractFromDatabaseWithCopy handles open error', async () => {
+    (fsMock as any).copyFileSync = jest.fn();
+    (fsMock as any).unlinkSync = jest.fn();
+    (fsMock as any).existsSync = jest.fn(() => false);
+
+    (sqlite3 as any).Database.mockImplementationOnce((p: string, m: any, cb: any) => { setImmediate(() => cb(new Error('fail'))); return mockDb; });
+
+    const ex = new ChromeCookieExtractor();
+    await expect((ex as any).extractFromDatabaseWithCopy('/p/Cookies')).rejects.toBeTruthy();
+    expect((fsMock as any).unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('extractFromDatabaseWithCopy with domain filter', async () => {
+    (fsMock as any).copyFileSync = jest.fn();
+    (fsMock as any).unlinkSync = jest.fn();
+    (fsMock as any).existsSync = jest.fn(() => true);
+
+    mockDb.run.mockImplementation((q, cb) => cb(null));
+    mockDb.all.mockImplementationOnce((q, cb) => cb(null, tableInfoRows));
+    mockDb.all.mockImplementationOnce((q, params, cb) => cb(null, []));
+    (sqlite3 as any).Database.mockImplementationOnce((p: string, m: any, cb: any) => { setImmediate(() => cb(null)); return mockDb; });
+
+    const ex = new ChromeCookieExtractor();
+    await (ex as any).extractFromDatabaseWithCopy('/p/Cookies', 'example');
+    expect((fsMock as any).copyFileSync).toHaveBeenCalled();
+  });
+});

--- a/tests/extractor-main.test.ts
+++ b/tests/extractor-main.test.ts
@@ -1,0 +1,60 @@
+import { ChromeCookieExtractor } from '../src/extractor';
+import { ProfileDetector } from '../src/profile-detector';
+import { Cookie } from '../src/types';
+
+jest.mock('../src/profile-detector', () => ({
+  ProfileDetector: { detectAllProfiles: jest.fn() }
+}));
+
+describe('ChromeCookieExtractor.extractCookies', () => {
+  const sample: Cookie = {
+    name: 'a',
+    value: '1',
+    domain: 'example.com',
+    path: '/',
+    expires: 0,
+    secure: false,
+    httponly: false,
+    creationTime: 0
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when no profiles found', async () => {
+    (ProfileDetector.detectAllProfiles as jest.Mock).mockReturnValue([]);
+    const ex = new ChromeCookieExtractor();
+    await expect(ex.extractCookies()).rejects.toThrow('No Chrome/Brave profiles found');
+  });
+
+  it('aggregates cookies from all profiles', async () => {
+    (ProfileDetector.detectAllProfiles as jest.Mock).mockReturnValue([
+      { name: 'Default', path: '/p1', cookiesPath: '/p1/c' },
+      { name: 'Profile1', path: '/p2', cookiesPath: '/p2/c' }
+    ]);
+    const spy = jest
+      .spyOn(ChromeCookieExtractor.prototype as any, 'extractFromDatabase')
+      .mockResolvedValue([sample]);
+    const ex = new ChromeCookieExtractor();
+    const cookies = await ex.extractCookies();
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(cookies.length).toBe(2);
+    spy.mockRestore();
+  });
+
+  it('filters by profile name', async () => {
+    (ProfileDetector.detectAllProfiles as jest.Mock).mockReturnValue([
+      { name: 'Default', path: '/p1', cookiesPath: '/p1/c' },
+      { name: 'Profile1', path: '/p2', cookiesPath: '/p2/c' }
+    ]);
+    const spy = jest
+      .spyOn(ChromeCookieExtractor.prototype as any, 'extractFromDatabase')
+      .mockResolvedValue([sample]);
+    const ex = new ChromeCookieExtractor();
+    const cookies = await ex.extractCookies({ profiles: ['Profile1'] });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(cookies.length).toBe(1);
+    spy.mockRestore();
+  });
+});

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -1,0 +1,68 @@
+import { ChromeCookieExtractor } from '../src/extractor';
+import { Cookie } from '../src/types';
+import * as fs from 'fs';
+
+jest.mock('../src/profile-detector', () => ({
+  ProfileDetector: { detectAllProfiles: jest.fn(() => []) }
+}));
+
+describe('ChromeCookieExtractor formatting', () => {
+  const extractor = new ChromeCookieExtractor();
+  const cookies: Cookie[] = [
+    {
+      name: 'session',
+      value: '123',
+      domain: '.example.com',
+      path: '/',
+      expires: 13253760000000000,
+      secure: true,
+      httponly: false,
+      creationTime: 0
+    },
+    {
+      name: 'enc',
+      value: '[ENCRYPTED]',
+      domain: 'example.com',
+      path: '/',
+      expires: 0,
+      secure: false,
+      httponly: false,
+      creationTime: 0
+    }
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('formats Netscape file correctly', () => {
+    const out = extractor.formatAsNetscape(cookies);
+    const lines = out.split('\n');
+    expect(lines[0]).toContain('Netscape HTTP Cookie File');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('.example.com');
+    expect(lines[1]).toContain('session');
+    expect(lines[1]).toContain('123');
+  });
+
+  it('formats curl header correctly', () => {
+    expect(extractor.formatAsCurl(cookies)).toBe('-H "Cookie: session=123"');
+    expect(extractor.formatAsCurl([cookies[1]])).toBe('');
+  });
+
+  it('formats JSON correctly', () => {
+    const json = extractor.formatAsJson([cookies[0]]);
+    const arr = JSON.parse(json);
+    expect(arr[0].name).toBe('session');
+    expect(arr).toHaveLength(1);
+  });
+
+  it('saves Netscape file to disk', () => {
+    const tmp = '/tmp/test.txt';
+    extractor.saveCookiesFile([cookies[0]], tmp);
+    const actualFs = jest.requireActual('fs') as typeof fs;
+    const data = actualFs.readFileSync(tmp, 'utf8');
+    expect(data).toContain('Netscape HTTP Cookie File');
+    actualFs.unlinkSync(tmp);
+  });
+});

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -1,0 +1,34 @@
+import { Factory } from '../src/factory';
+import { IOStreams } from '../src/iostreams';
+import { ChromeCookieExtractor } from '../src/extractor';
+
+jest.mock('../src/iostreams');
+jest.mock('../src/extractor');
+
+describe('Factory', () => {
+  beforeEach(() => {
+    (IOStreams as jest.MockedClass<typeof IOStreams>).mockClear();
+    (ChromeCookieExtractor as jest.MockedClass<typeof ChromeCookieExtractor>).mockClear();
+    (IOStreams as jest.MockedClass<typeof IOStreams>).prototype.canPrompt.mockReturnValue(true);
+  });
+
+  it('reuses singleton instances', () => {
+    const factory = new Factory();
+    const a = factory.getIOStreams();
+    const b = factory.getIOStreams();
+    expect(a).toBe(b);
+    expect(IOStreams).toHaveBeenCalledTimes(1);
+
+    const x = factory.getExtractor();
+    const y = factory.getExtractor();
+    expect(x).toBe(y);
+    expect(ChromeCookieExtractor).toHaveBeenCalledTimes(1);
+  });
+
+  it('canPrompt delegates to IOStreams', () => {
+    const factory = new Factory();
+    const result = factory.canPrompt();
+    expect(result).toBe(true);
+    expect(IOStreams.prototype.canPrompt).toHaveBeenCalled();
+  });
+});

--- a/tests/iostreams.test.ts
+++ b/tests/iostreams.test.ts
@@ -1,0 +1,50 @@
+import { IOStreams } from '../src/iostreams';
+import { Writable } from 'stream';
+
+describe('IOStreams', () => {
+  let stdoutData = '';
+  let stderrData = '';
+  const stdout = new Writable({
+    write(chunk, _enc, cb) {
+      stdoutData += chunk.toString();
+      cb();
+    }
+  }) as any;
+  const stderr = new Writable({
+    write(chunk, _enc, cb) {
+      stderrData += chunk.toString();
+      cb();
+    }
+  }) as any;
+  const stdin: any = { isTTY: true };
+  stdout.isTTY = true;
+
+  let streams: IOStreams;
+
+  beforeEach(() => {
+    stdoutData = '';
+    stderrData = '';
+    streams = new IOStreams();
+    (streams as any)._stdin = stdin;
+    (streams as any)._stdout = stdout;
+    (streams as any)._stderr = stderr;
+  });
+
+  it('canPrompt returns true when tty', () => {
+    expect(streams.canPrompt()).toBe(true);
+  });
+
+  it('print helpers output to streams', () => {
+    streams.print('hello');
+    streams.printError('bad');
+    streams.printWarning('warn');
+    streams.printSuccess('yay');
+    streams.printInfo('info');
+
+    expect(stdoutData).toContain('hello\n');
+    expect(stderrData).toContain('Error: bad\n');
+    expect(stderrData).toContain('Warning: warn\n');
+    expect(stdoutData).toContain('✅ yay\n');
+    expect(stdoutData).toContain('ℹ️ info\n');
+  });
+});

--- a/tests/profile-detector.test.ts
+++ b/tests/profile-detector.test.ts
@@ -48,6 +48,40 @@ describe('ProfileDetector', () => {
       expect(profiles[0]).toHaveProperty('path');
       expect(profiles[0]).toHaveProperty('cookiesPath');
     });
+
+    it('should detect Chrome profiles on win32', () => {
+      mockOs.platform.mockReturnValue('win32');
+      mockOs.homedir.mockReturnValue('C:/Users/test');
+      mockFs.existsSync.mockImplementation((p: any) => {
+        const s = p.toString();
+        if (s === 'C:/Users/test/AppData/Local/Google/Chrome/User Data') return true;
+        if (s === 'C:/Users/test/AppData/Local/Google/Chrome/User Data/Default/Cookies') return true;
+        return false;
+      });
+
+      const profiles = ProfileDetector.detectChromeProfiles();
+      expect(profiles.length).toBeGreaterThan(0);
+    });
+
+    it('should detect Chrome profiles on linux', () => {
+      mockOs.platform.mockReturnValue('linux');
+      mockOs.homedir.mockReturnValue('/home/test');
+      mockFs.existsSync.mockImplementation((p: any) => {
+        const s = p.toString();
+        if (s === '/home/test/.config/google-chrome') return true;
+        if (s === '/home/test/.config/google-chrome/Default/Cookies') return true;
+        return false;
+      });
+
+      const profiles = ProfileDetector.detectChromeProfiles();
+      expect(profiles.length).toBeGreaterThan(0);
+    });
+
+    it('should throw on unsupported platform', () => {
+      mockOs.platform.mockReturnValue('aix');
+      mockOs.homedir.mockReturnValue('/tmp');
+      expect(() => ProfileDetector.detectChromeProfiles()).toThrow();
+    });
   });
 
   describe('detectBraveProfiles', () => {
@@ -59,6 +93,34 @@ describe('ProfileDetector', () => {
       const profiles = ProfileDetector.detectBraveProfiles();
 
       expect(profiles).toEqual([]);
+    });
+
+    it('should detect Brave profiles on linux', () => {
+      mockOs.platform.mockReturnValue('linux');
+      mockOs.homedir.mockReturnValue('/home/test');
+      mockFs.existsSync.mockImplementation((p: any) => {
+        const s = p.toString();
+        if (s === '/home/test/.config/BraveSoftware/Brave-Browser') return true;
+        if (s === '/home/test/.config/BraveSoftware/Brave-Browser/Default/Cookies') return true;
+        return false;
+      });
+
+      const profiles = ProfileDetector.detectBraveProfiles();
+      expect(profiles.length).toBeGreaterThan(0);
+    });
+
+    it('should detect Brave profiles on win32', () => {
+      mockOs.platform.mockReturnValue('win32');
+      mockOs.homedir.mockReturnValue('C:/Users/test');
+      mockFs.existsSync.mockImplementation((p: any) => {
+        const s = p.toString();
+        if (s === 'C:/Users/test/AppData/Local/BraveSoftware/Brave-Browser/User Data') return true;
+        if (s === 'C:/Users/test/AppData/Local/BraveSoftware/Brave-Browser/User Data/Default/Cookies') return true;
+        return false;
+      });
+
+      const profiles = ProfileDetector.detectBraveProfiles();
+      expect(profiles.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
- Normalize incoming value to a Buffer so Uint8Array or raw arrays work
- Always use the normalized buffer for decryption/fallback-to-utf8
